### PR TITLE
Sender is now responsible only for "transport"

### DIFF
--- a/bin/kafka-rest
+++ b/bin/kafka-rest
@@ -9,7 +9,7 @@ app_path = ENV['APP_PATH'] || '.'
 require 'kafka_rest/logging'
 require 'kafka_rest/worker'
 
-require File.expand_path(app_path, 'config/environment.rb')
+require File.expand_path('config/environment.rb', app_path)
 
 Rails.application.eager_load!
 

--- a/lib/kafka_rest.rb
+++ b/lib/kafka_rest.rb
@@ -1,10 +1,14 @@
+module KafkaRest; end
+
+require 'kafka_rest/exceptions'
+require 'kafka_rest/sender'
 require 'kafka_rest/config'
 require 'kafka_rest/logging'
 require 'kafka_rest/client'
 require 'kafka_rest/worker'
 require 'kafka_rest/producer'
+require 'kafka_rest/producer/message'
 require 'kafka_rest/producer/serialization/adapter'
-require 'kafka_rest/sender'
 require 'kafka_rest/consumer'
 
 KafkaRest.configure do |c|

--- a/lib/kafka_rest/client/middleware.rb
+++ b/lib/kafka_rest/client/middleware.rb
@@ -4,19 +4,6 @@ require 'multi_json'
 
 module KafkaRest
   class Client
-    class KafkaRestClientException < StandardError
-      attr_reader :body, :status
-
-      def initialize(resp)
-        @body = resp.body
-        @status = resp.status
-
-        super "#{@body['message']}" +
-              " (HTTP Status: #{@status}; " +
-              "error code: #{@body['error_code']})"
-      end
-    end
-
     class DefaultHeaders < Faraday::Middleware
       def initialize(app = nil, default_headers = {})
         @default_headers = default_headers
@@ -50,7 +37,7 @@ module KafkaRest
         response = @app.call(env)
         response.on_complete do
           unless response.success?
-            raise KafkaRestClientException.new(response)
+            raise ClientError.new(response)
           end
         end
       end

--- a/lib/kafka_rest/config.rb
+++ b/lib/kafka_rest/config.rb
@@ -5,7 +5,8 @@ module KafkaRest
                   :serialization_adapter,
                   :worker_min_threads,
                   :worker_max_threads,
-                  :worker_max_queue
+                  :worker_max_queue,
+                  :sender
 
     def initialize
       @url = 'http://localhost:8082'
@@ -14,6 +15,15 @@ module KafkaRest
       @worker_min_threads = 4
       @worker_max_threads = 4
       @worker_max_queue = nil
+      @sender = KafkaRest::Sender::KafkaSender
+    end
+
+    def sender=(_sender)
+      if KafkaRest::Sender.valid?(_sender)
+        @sender = _sender
+      else
+        raise InvalidConfigValue.new("sender", _sender, "Sender be a child of `KafkaRest::Sender`")
+      end
     end
   end
 

--- a/lib/kafka_rest/exceptions.rb
+++ b/lib/kafka_rest/exceptions.rb
@@ -1,0 +1,29 @@
+module KafkaRest
+  class InvalidConfigValue < StandardError
+    def initialize(name, val, msg = nil)
+      message = "Invalid config for `#{name}`: #{val.to_s}"
+      message << ". #{msg}" if msg
+
+      super message
+    end
+  end
+
+  class ClientError < StandardError
+    attr_reader :body, :status, :error_code
+
+    def initialize(resp)
+      @body = resp.body
+      @status = resp.status
+      @error_code = @body['error_code']
+
+      super "#{@body['message']}" +
+            " (HTTP Status: #{@status}; " +
+            "error code: #{@status})"
+    end
+  end
+
+  class ProducerSendError < StandardError
+  end
+
+  class ConsumerError < StandardError; end
+end

--- a/lib/kafka_rest/producer.rb
+++ b/lib/kafka_rest/producer.rb
@@ -1,4 +1,5 @@
 require 'kafka_rest/dsl'
+require 'kafka_rest/producer/payload'
 
 module KafkaRest
   module Producer
@@ -60,9 +61,15 @@ module KafkaRest
     end
 
     module ClassMethods
-      def send!(obj, opts = {}, producer = nil)
-        (producer || KafkaRest::Sender.instance)
-          .send!(self, obj, opts)
+      def build_message(obj, opts = {})
+        Message.new(self, obj, opts)
+      end
+
+      def send!(obj, opts = {}, sender = nil)
+        sender  = sender || KafkaRest.config.sender
+        message = build_message(obj, opts)
+
+        sender.send!(message)
       end
     end
   end

--- a/lib/kafka_rest/producer/message.rb
+++ b/lib/kafka_rest/producer/message.rb
@@ -1,0 +1,27 @@
+module KafkaRest
+  module Producer
+    class Message
+      attr_reader :topic, :payload, :format, :params
+
+      def initialize(producer, obj, opts = {})
+        @topic    = producer.get_topic.to_s
+        @payload  = Payload.new(producer, obj, opts).build
+        @format   = producer.get_format.to_s
+        @params   = build_params(producer)
+      end
+
+      private
+
+      # add schemas if format == 'avro'
+      def build_params(producer)
+        {}.tap do |params|
+          if @format == 'avro'
+            has_key = !producer.get_key.nil?
+            params[:key_schema] = producer.get_key_schema if has_key
+            params[:value_schema] = producer.get_value_schema
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka_rest/producer/payload.rb
+++ b/lib/kafka_rest/producer/payload.rb
@@ -1,10 +1,10 @@
-require 'kafka_rest/sender/payload/builder'
-require 'kafka_rest/sender/payload/avro_builder'
-require 'kafka_rest/sender/payload/json_builder'
-require 'kafka_rest/sender/payload/binary_builder'
+require 'kafka_rest/producer/payload/builder'
+require 'kafka_rest/producer/payload/avro_builder'
+require 'kafka_rest/producer/payload/json_builder'
+require 'kafka_rest/producer/payload/binary_builder'
 
 module KafkaRest
-  class Sender
+  module Producer
     class Payload
       attr_reader :klass
 

--- a/lib/kafka_rest/producer/payload/avro_builder.rb
+++ b/lib/kafka_rest/producer/payload/avro_builder.rb
@@ -1,5 +1,5 @@
 module KafkaRest
-  class Sender
+  module Producer
     class Payload
       class AvroBuilder < Builder
         # TODO: get rid of this

--- a/lib/kafka_rest/producer/payload/binary_builder.rb
+++ b/lib/kafka_rest/producer/payload/binary_builder.rb
@@ -1,7 +1,7 @@
 require 'base64'
 
 module KafkaRest
-  class Sender
+  module Producer
     class Payload
       class BinaryBuilder < Builder
         def build

--- a/lib/kafka_rest/producer/payload/builder.rb
+++ b/lib/kafka_rest/producer/payload/builder.rb
@@ -1,5 +1,5 @@
 module KafkaRest
-  class Sender
+  module Producer
     class Payload
       class Builder
         def initialize(payload)

--- a/lib/kafka_rest/producer/payload/json_builder.rb
+++ b/lib/kafka_rest/producer/payload/json_builder.rb
@@ -1,5 +1,5 @@
 module KafkaRest
-  class Sender
+  module Producer
     class Payload
       class JsonBuilder < Builder
         def build

--- a/lib/kafka_rest/sender.rb
+++ b/lib/kafka_rest/sender.rb
@@ -1,81 +1,13 @@
 require 'thread'
-require 'kafka_rest/sender/payload'
 
 module KafkaRest
-  class Sender
-    @@lock = Mutex.new
+  module Sender
+    require 'kafka_rest/sender/kafka_sender'
+    require 'kafka_rest/sender/log_sender'
+    require 'kafka_rest/sender/test_sender'
 
-    class << self
-      def instance
-        @@lock.synchronize do
-          @instance ||= self.new(Client.new, lock: @@lock)
-        end
-      end
-    end
-
-    attr_reader :key_schema_cache, :value_schema_cache
-
-    # TODO: buffering???
-    def initialize(client, opts = {})
-      @lock = opts[:lock] || Mutex.new
-      @client = client
-      @key_schema_cache = {}
-      @value_schema_cache = {}
-    end
-
-    # TODO: back-off retry if offset[i].errors is a retriable error
-    def send!(klass, obj, opts = {})
-      topic, payload, format, params = build_request(klass, obj, opts)
-      send_produce_request!(topic, payload, format, params)
-    end
-
-    private
-
-    def build_request(klass, obj, opts)
-      # TODO: oooh, dirty and weird - this should not be here.
-      #       come up with something good!
-      topic    = klass.get_topic.to_s
-      key      = klass.get_key
-      payload  = Payload.new(klass, obj, opts).build
-      format   = klass.get_format.to_s
-      params   = {}.tap do |_p|
-        if format == 'avro'
-          unless key.nil?
-            if kid = @key_schema_cache[topic]
-              _p[:key_schema_id] = kid
-            else
-              _p[:key_schema] = klass.get_key_schema
-            end
-          end
-
-          if vid = @value_schema_cache[topic]
-            _p[:value_schema_id] = vid
-          else
-            _p[:value_schema] = klass.get_value_schema
-          end
-        end
-      end
-
-      [topic, payload, format, params]
-    end
-
-    def send_produce_request!(topic, payload, format, params)
-      @client.topic_produce_message(topic, payload, format, params).body.tap do |re|
-        # this too (line 27)
-        cache_schema_ids!(re, topic) if format == 'avro'
-      end['offsets']
-    end
-
-    def cache_schema_ids!(resp, topic)
-      @lock.synchronize do
-        if @key_schema_cache[topic].nil? && kid = resp['key_schema_id']
-          @key_schema_cache[topic] = kid
-        end
-
-        if @value_schema_cache[topic].nil? && vid = resp['value_schema_id']
-          @value_schema_cache[topic] = vid
-        end
-      end
+    def self.valid?(sender)
+      sender.respond_to? :send!
     end
   end
 end

--- a/lib/kafka_rest/sender/kafka_sender.rb
+++ b/lib/kafka_rest/sender/kafka_sender.rb
@@ -1,0 +1,84 @@
+module KafkaRest
+  module Sender
+    class KafkaSender
+
+      @@instance = nil
+
+      class << self
+        def instance
+          @@instance ||= self.new(Client.new)
+        end
+
+        def send!(message)
+          instance.send!(message)
+        end
+      end
+
+      attr_reader :key_schema_cache, :value_schema_cache
+
+      def initialize(client, opts = {})
+        @lock = Mutex.new
+        @client = client
+        @key_schema_cache = {}
+        @value_schema_cache = {}
+      end
+
+      # TODO: back-off retry if offset[i].errors is a retriable error
+      def send!(message)
+        send_produce_request!(
+          message.topic,
+          message.payload,
+          message.format,
+          build_params(message)
+        )
+      end
+
+      private
+
+      # replace key and value schemas with
+      # their ids if those are found in cache
+      def build_params(message)
+        return message.params unless message.format == 'avro'
+
+        topic, params, format = message.topic, message.params, message.format
+
+        {}.tap do |_p|
+          if format == 'avro'
+            if key_schema = params[:key_schema]
+              if key_schema_id = @key_schema_cache[topic]
+                _p[:key_schema_id] = key_schema_id
+              else
+                _p[:key_schema] = key_schema
+              end
+            end
+
+            if value_schema_id = @value_schema_cache[topic]
+              _p[:value_schema_id] = value_schema_id
+            else
+              _p[:value_schema] = params[:value_schema]
+            end
+          end
+        end
+      end
+
+      def send_produce_request!(topic, payload, format, params)
+        @client.topic_produce_message(topic, payload, format, params).body.tap do |re|
+          # this too (line 27)
+          cache_schema_ids!(re, topic) if format == 'avro'
+        end['offsets']
+      end
+
+      def cache_schema_ids!(resp, topic)
+        @lock.synchronize do
+          if @key_schema_cache[topic].nil? && kid = resp['key_schema_id']
+            @key_schema_cache[topic] = kid
+          end
+
+          if @value_schema_cache[topic].nil? && vid = resp['value_schema_id']
+            @value_schema_cache[topic] = vid
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka_rest/sender/log_sender.rb
+++ b/lib/kafka_rest/sender/log_sender.rb
@@ -1,0 +1,24 @@
+module KafkaRest
+  module Sender
+    class LogSender
+      def initialize(logger = nil)
+        @logger = logger || Logging.logger
+      end
+
+      def send!(msg)
+        @logger.info "\n[Kafka REST] Produced a message: #{make_string(msg)}\n"
+      end
+
+      private
+
+      def make_string(msg)
+        [
+          "\n\ttopic  = #{msg.topic}",
+          "format = #{msg.format}",
+          "key    = #{msg.payload[:key]}",
+          "value  = #{msg.payload[:value]}",
+        ].join "\n\t"
+      end
+    end
+  end
+end

--- a/lib/kafka_rest/sender/test_sender.rb
+++ b/lib/kafka_rest/sender/test_sender.rb
@@ -1,0 +1,28 @@
+module KafkaRest
+  module Sender
+    class TestSender
+      attr_reader :messages
+
+      def initialize
+        @lock     = Mutex.new
+        @messages = {}
+      end
+
+      def send!(message)
+        @lock.synchronize do
+          topic = message.topic
+          @messages[topic] ||= []
+          @messages[topic] << message
+        end
+      end
+
+      def last_for(topic)
+        @messages[topic].last
+      end
+
+      def reset!
+        @messages = {}
+      end
+    end
+  end
+end

--- a/lib/kafka_rest/version.rb
+++ b/lib/kafka_rest/version.rb
@@ -1,3 +1,3 @@
 module KafkaRest
-  VERSION = '0.1.0.alpha3'
+  VERSION = '0.1.0.alpha4'
 end

--- a/lib/kafka_rest/version.rb
+++ b/lib/kafka_rest/version.rb
@@ -1,3 +1,3 @@
 module KafkaRest
-  VERSION = '0.1.0.alpha4'
+  VERSION = '0.1.0.alpha5'
 end

--- a/perf/perftest
+++ b/perf/perftest
@@ -38,8 +38,8 @@ class Test
     @workers = []
 
     @parallelism = config[:parallelism]     || 4
-    @msg_count   = config[:msg_count]       || 1000
-    @send_interval = config[:send_interval] || 0.1
+    @msg_count   = config[:msg_count]       || 10000
+    @send_interval = config[:send_interval] || 0
 
     @success_count = 0
     @errored_count = 0

--- a/spec/kafka_rest/kafka_sender_spec.rb
+++ b/spec/kafka_rest/kafka_sender_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'ostruct'
 
-describe KafkaRest::Sender do
+describe KafkaRest::Sender::KafkaSender do
   class MockClient
     def topic_produce_message(topic, payload, format)
       :O_O
@@ -16,8 +16,9 @@ describe KafkaRest::Sender do
     }
   end
 
-  subject { sender.send!(klass, obj) }
+  subject { sender.send!(msg) }
 
+  let(:msg) { KafkaRest::Producer::Message.new(klass, obj) }
   let(:sender) { described_class.new(client) }
   let(:client) { MockClient.new }
   let(:obj) { "test" }
@@ -66,7 +67,7 @@ describe KafkaRest::Sender do
     it 'uses schema ids instead of schemas in payload if found' do
       subject
 
-      params = sender.send(:build_request, klass, obj, {}).last
+      params = sender.send(:build_params, msg)
 
       expect(params).to have_key(:key_schema_id)
       expect(params).to have_key(:value_schema_id)

--- a/spec/kafka_rest/producer/payload_spec.rb
+++ b/spec/kafka_rest/producer/payload_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe KafkaRest::Sender::Payload do
+describe KafkaRest::Producer::Payload do
   let(:obj) { "test" }
   let(:payload) { described_class.new(klass, obj) }
 

--- a/spec/kafka_rest/producer_spec.rb
+++ b/spec/kafka_rest/producer_spec.rb
@@ -20,8 +20,13 @@ describe KafkaRest::Producer do
 
     it 'sends a message' do
       obj = "test"
-      expect(KafkaRest::Sender.instance)
-        .to receive(:send!).with(klass, obj, {})
+      msg = KafkaRest::Producer::Message.new(klass, obj)
+
+      expect(JsonProducer1)
+        .to receive(:build_message).and_return(msg)
+
+      expect(KafkaRest::Sender::KafkaSender.instance)
+        .to receive(:send!).with(msg)
 
       klass.send!(obj)
     end


### PR DESCRIPTION
- Introduced `Message` class
- Changed `Sender`'s responsibility
- `LogSender` for sending messages to logger instead of kafka-rest (for dev-modes)
- `TestSender` mock
